### PR TITLE
Version bump to 0.1.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "obsidian-open-link-with",
     "name": "Open Link With",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "minAppVersion": "1.1",
     "description": "Open external link with specific browser / in-app view in Obsidian",
     "author": "MamoruDS",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-open-link-with",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Open external link with specific browser / in-app view in Obsidian",
     "main": "dist/main.js",
     "scripts": {

--- a/src/click.ts
+++ b/src/click.ts
@@ -14,7 +14,7 @@ const checkClickable = (el: Element): Clickable => {
         is_clickable: false,
         url: undefined, // might be invalid; check before return
         popout: false,
-        require_modifier: [],
+        required_modifiers: [],
     } as Clickable
     // example of el with `external-link`:
     //  - links in preview mode
@@ -38,7 +38,7 @@ const checkClickable = (el: Element): Clickable => {
     if (el.classList.contains('cm-url')) {
         res.is_clickable = true
         res.url = el.innerHTML.trim()
-        res.require_modifier = Platform.isMacOS
+        res.required_modifiers = Platform.isMacOS
             ? [Modifier.Meta]
             : [Modifier.Ctrl]
     }
@@ -120,6 +120,7 @@ class LocalDocClickHandler {
             is_aux: this.handleAuxClick,
             clickable,
             url,
+            modifiers,
             dummy,
             btn: evt.button,
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import {
     debounce,
     Debouncer,
     Modal,
+    PaneType,
     Plugin,
     PluginSettingTab,
     Setting,
@@ -99,6 +100,7 @@ export default class OpenLinkPlugin
             } else if (shiftKey) {
                 modifier = 'shift'
             }
+            // const modifiers = getModifiersFromMouseEvt(evt)
             const url = el.getAttr('href')
             const matchedMB: ModifierBinding | undefined =
                 this.settings.modifierBindings.find((mb) => {
@@ -109,8 +111,10 @@ export default class OpenLinkPlugin
                     }
                 })
             const profileName = matchedMB?.browser ?? this.settings.selected
-            const popupWindow =
-                el.getAttr('target') === '_blank' ? true : false
+            const paneType =
+                el.getAttr('target') === '_blank'
+                    ? 'window' // higher priority
+                    : (el.getAttr('oolw-pane-type') as PaneType) || undefined
             const cmd = this._getOpenCMD(profileName)
             if (this.settings.enableLog) {
                 log('info', 'click event (extLinkClick)', {
@@ -128,8 +132,9 @@ export default class OpenLinkPlugin
                     mid: (evt.doc.win as MWindow).mid,
                     url,
                     profileName,
-                    popupWindow,
+                    paneType,
                     cmd,
+                    matchedBinding: matchedMB,
                 })
             }
             // right click trigger (windows only)
@@ -143,16 +148,16 @@ export default class OpenLinkPlugin
             if (profileName === BROWSER_IN_APP.val) {
                 evt.preventDefault()
                 this._viewmgr.createView(url, ViewMode.NEW, {
-                    popupWindow,
                     focus: matchedMB?.focusOnView,
+                    paneType,
                 })
                 return
             }
             if (profileName === BROWSER_IN_APP_LAST.val) {
                 evt.preventDefault()
                 this._viewmgr.createView(url, ViewMode.LAST, {
-                    popupWindow,
                     focus: matchedMB?.focusOnView,
+                    paneType,
                 })
                 return
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -379,7 +379,7 @@ class SettingTab extends PluginSettingTab {
                         platform: Platform.Unknown,
                         modifier: 'none',
                         focusOnView: true,
-                        auxClickOnly: true,
+                        auxClickOnly: false,
                     })
                     await this.plugin.saveSettings()
                     this._render()

--- a/src/main.ts
+++ b/src/main.ts
@@ -180,7 +180,7 @@ export default class OpenLinkPlugin
         //
         this.addSettingTab(new SettingTab(this.app, this))
         //
-        this._windowUtils = new WindowUtils()
+        this._windowUtils = new WindowUtils(this)
         this._clickUtils = new ClickUtils(this, this._windowUtils)
         const initWindow = (win: MWindow) => {
             this._windowUtils.registerWindow(win)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -5,14 +5,14 @@ import {
     Browser as _Browser,
     BrowserProfile,
     BrowserProfileBase,
+    ProfileMgrITF,
 } from './types'
 
 class Browser implements _Browser {
-    name: string
-    profiles: Partial<Record<NodeJS.Platform, BrowserProfile>>
-    customCMD: string
+    public profiles: Partial<Record<NodeJS.Platform, BrowserProfile>>
+    public customCMD: string
     constructor(
-        name: string,
+        public name: string,
         defaultCMD?: Partial<Record<NodeJS.Platform, BrowserProfile>>
     ) {
         this.name = name
@@ -71,7 +71,7 @@ const getPresetBrowsers = (): Browser[] => {
     return presets
 }
 
-class ProfileMgr {
+class ProfileMgr implements ProfileMgrITF {
     private _preset_browser: Browser[]
     private _browsers: Browser[]
     constructor() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,18 @@ enum Platform {
     Win = 'win',
 }
 
+class _MatchRule<R> {
+    constructor(public items: R[]) {}
+}
+
+class MRExact<R> extends _MatchRule<R> {}
+
+class MRContains<R> extends _MatchRule<R> {}
+
+class MRNotExact<R> extends _MatchRule<R> {}
+
+class MRNotContains<R> extends _MatchRule<R> {}
+
 enum Modifier {
     Alt = 'alt',
     Ctrl = 'ctrl',
@@ -87,6 +99,11 @@ export {
     BrowserProfileBase,
     Clickable,
     LogLevels,
+    _MatchRule,
+    MRExact,
+    MRContains,
+    MRNotExact,
+    MRNotContains,
     Modifier,
     ModifierBinding,
     MouseButton,

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,9 +79,10 @@ interface ModifierBinding {
     id: string
     browser?: string
     platform: Platform
-    modifier: ValidModifier
-    focusOnView: boolean
+    modifier: ValidModifier // TODO:
+    focusOnView?: boolean
     auxClickOnly: boolean
+    paneType?: PaneType
 }
 
 interface OpenLinkPluginITF extends Plugin {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Plugin } from 'obsidian'
+
 type Optional<T> = T | undefined
 
 enum Platform {
@@ -32,6 +34,11 @@ enum MouseButton {
     Secondary,
     Fourth,
     Fifth,
+}
+
+enum ViewMode {
+    LAST,
+    NEW,
 }
 
 interface BrowserOptions {
@@ -69,9 +76,33 @@ interface ModifierBinding {
     auxClickOnly: boolean
 }
 
+interface OpenLinkPluginITF extends Plugin {
+    settings: PluginSettings
+    profiles: ProfileMgrITF
+    loadSettings(): Promise<void>
+    saveSettings(): Promise<void>
+}
+
+interface PluginSettings {
+    selected: string
+    custom: Record<string, string[]>
+    modifierBindings: ModifierBinding[]
+    enableLog: boolean
+    timeout: number
+    inAppViewRec: ViewRec[]
+}
+
 interface ProfileDisplay {
     val: string
     display?: string
+}
+
+interface ProfileMgrITF {
+    loadValidPresetBrowsers: () => Promise<void>
+    getBrowsers: () => Browser[]
+    getBrowsersCMD: (
+        custom: Record<string, string[]>
+    ) => Record<string, string[]>
 }
 
 interface MWindow extends Window {
@@ -92,6 +123,12 @@ type LogLevels = 'info' | 'warn' | 'error'
 
 type ValidModifier = 'none' | 'ctrl' | 'meta' | 'alt' | 'shift'
 
+type ViewRec = {
+    leafId: string
+    url: string
+    mode: ViewMode
+}
+
 export {
     Browser,
     BrowserOptions,
@@ -108,8 +145,13 @@ export {
     ModifierBinding,
     MouseButton,
     MWindow,
+    OpenLinkPluginITF,
     Optional,
     Platform,
+    PluginSettings,
     ProfileDisplay,
+    ProfileMgrITF,
     ValidModifier,
+    ViewMode,
+    ViewRec,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,9 +83,9 @@ interface MWindow extends Window {
 
 type Clickable = {
     is_clickable: boolean
-    url: string | undefined
+    url: string | null
     popout: boolean
-    required_modifiers?: Modifier[]
+    modifier_rules?: _MatchRule<Modifier>[]
 }
 
 type LogLevels = 'info' | 'warn' | 'error'

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ type Clickable = {
     is_clickable: boolean
     url: string | undefined
     popout: boolean
-    require_modifier?: Modifier[]
+    required_modifiers?: Modifier[]
 }
 
 type LogLevels = 'info' | 'warn' | 'error'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,26 @@
-import { Plugin } from 'obsidian'
+import { PaneType, Plugin } from 'obsidian'
 
 type Optional<T> = T | undefined
+
+namespace Rule {
+    export class _Rule<R, V> {
+        constructor(public items: R[], public value: V) {}
+    }
+
+    export class Empty<R, V> extends _Rule<R, V> {
+        constructor(value: V) {
+            super([], value)
+        }
+    }
+
+    export class Exact<R, V> extends _Rule<R, V> {}
+
+    export class Contains<R, V> extends _Rule<R, V> {}
+
+    export class NotExact<R, V> extends _Rule<R, V> {}
+
+    export class NotContains<R, V> extends _Rule<R, V> {}
+}
 
 enum Platform {
     Unknown = 'unknown',
@@ -8,18 +28,6 @@ enum Platform {
     Mac = 'mac',
     Win = 'win',
 }
-
-class _MatchRule<R> {
-    constructor(public items: R[]) {}
-}
-
-class MRExact<R> extends _MatchRule<R> {}
-
-class MRContains<R> extends _MatchRule<R> {}
-
-class MRNotExact<R> extends _MatchRule<R> {}
-
-class MRNotContains<R> extends _MatchRule<R> {}
 
 enum Modifier {
     Alt = 'alt',
@@ -113,10 +121,10 @@ interface MWindow extends Window {
 }
 
 type Clickable = {
-    is_clickable: boolean
+    is_clickable: boolean | null
     url: string | null
-    popout: boolean
-    modifier_rules?: _MatchRule<Modifier>[]
+    paneType?: PaneType
+    modifier_rules?: Rule._Rule<Modifier, Optional<PaneType> | false>[]
 }
 
 type LogLevels = 'info' | 'warn' | 'error'
@@ -136,11 +144,6 @@ export {
     BrowserProfileBase,
     Clickable,
     LogLevels,
-    _MatchRule,
-    MRExact,
-    MRContains,
-    MRNotExact,
-    MRNotContains,
     Modifier,
     ModifierBinding,
     MouseButton,
@@ -151,6 +154,7 @@ export {
     PluginSettings,
     ProfileDisplay,
     ProfileMgrITF,
+    Rule,
     ValidModifier,
     ViewMode,
     ViewRec,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,48 @@
-import { LogLevels, Modifier, MWindow, Platform, ValidModifier } from './types'
+import {
+    LogLevels,
+    _MatchRule,
+    MRExact,
+    MRContains,
+    MRNotExact,
+    MRNotContains,
+    Modifier,
+    MWindow,
+    Platform,
+    ValidModifier,
+} from './types'
+
+class RulesChecker<R> {
+    private _rules: _MatchRule<R>[]
+    constructor(rules: _MatchRule<R>[] = []) {
+        this._rules = rules
+    }
+    addRule(rule: _MatchRule<R>) {
+        this._rules.push(rule)
+    }
+    check(input: R[]): boolean {
+        let success = false
+        for (const rule of this._rules) {
+            const { items } = rule
+            if (rule instanceof MRExact || rule instanceof MRNotExact) {
+                let res = false
+                if (items.length === input.length) {
+                    res = items.every((item) => input.contains(item))
+                }
+                success = success || (rule instanceof MRExact ? res : !res)
+            } else if (
+                rule instanceof MRContains ||
+                rule instanceof MRNotContains
+            ) {
+                let res = false
+                if (items.length <= input.length) {
+                    res = items.every((item) => input.contains(item))
+                }
+                success = success || (rule instanceof MRContains ? res : !res)
+            }
+        }
+        return success
+    }
+}
 
 class WindowUtils {
     private _windows: Record<string, MWindow>
@@ -138,5 +182,6 @@ export {
     getValidHttpURL,
     intersection,
     log,
+    RulesChecker,
     WindowUtils,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import {
     MWindow,
     Platform,
     ValidModifier,
+    OpenLinkPluginITF,
 } from './types'
 
 class RulesChecker<R> {
@@ -46,7 +47,7 @@ class RulesChecker<R> {
 
 class WindowUtils {
     private _windows: Record<string, MWindow>
-    constructor() {
+    constructor(private _plugin: OpenLinkPluginITF) {
         this._windows = {}
     }
     initWindow(win: MWindow) {
@@ -56,14 +57,18 @@ class WindowUtils {
     registerWindow(win: MWindow) {
         if (typeof win.mid === 'undefined') {
             win = this.initWindow(win)
-            log('info', 'window registered', { mid: win.mid, window: win })
+            if (this._plugin.settings.enableLog) {
+                log('info', 'window registered', { mid: win.mid, window: win })
+            }
             this._windows[win.mid] = win
         } else {
             // panic
-            // log('warn', 'existing window registered', {
-            //     mid: win.mid,
-            //     window: win,
-            // })
+            // if (this._plugin.settings.enableLog) {
+            //     log('warn', 'existing window registered', {
+            //         mid: win.mid,
+            //         window: win,
+            //     })
+            // }
         }
     }
     unregisterWindow(win: MWindow) {
@@ -134,11 +139,7 @@ const getValidHttpURL = (url?: string | URL): string | null => {
             : null
     } else {
         try {
-            if (['http:', 'https:'].indexOf(new URL(url).protocol) != -1) {
-                return url
-            } else {
-                return null
-            }
+            return getValidHttpURL(new URL(url))
         } catch (TypeError) {
             return null
         }

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,24 +1,13 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian'
 import { BuiltinIcon } from './obsidian/types'
-import OpenLinkPlugin from './main'
+import { OpenLinkPluginITF, ViewMode, ViewRec } from './types'
 import { log } from './utils'
 
-enum ViewMode {
-    LAST,
-    NEW,
-}
-
-type ViewRec = {
-    leafId: string
-    url: string
-    mode: ViewMode
-}
-
 class InAppView extends ItemView {
-    icon: BuiltinIcon = 'link'
-    frame: HTMLIFrameElement
-    title: string
-    url: string
+    public icon: BuiltinIcon = 'link'
+    public frame: HTMLIFrameElement
+    public title: string
+    public url: string
     constructor(leaf: WorkspaceLeaf, url: string) {
         super(leaf)
         this.url = url
@@ -44,11 +33,8 @@ class InAppView extends ItemView {
 }
 
 class ViewMgr {
-    plugin: OpenLinkPlugin
-    constructor(plugin: OpenLinkPlugin) {
-        this.plugin = plugin
-    }
-    // private _getLeafID(leaf: WorkspaceLeaf): string {
+    constructor(public plugin: OpenLinkPluginITF) {}
+    // private _getLeafID(leaf: WorkspaceLeaf): string
     // FIXME: missing property
     private _getLeafId(leaf: any): string {
         return leaf['id'] ?? ''


### PR DESCRIPTION
-   fixed: external-link click ignored under live preview mode
-   added: more and native [pane-type](https://github.com/obsidianmd/obsidian-api/blob/38dd22168d2925086371bfc59e36fd9121527a39/obsidian.d.ts#L2591) support for creating views
-   improved: using rule-based checker for `clickable` checking
-   improved: in-app view opening now follows Obsidian's click behaviors