### PR TITLE
Version bump to 0.1.10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "obsidian-open-link-with",
     "name": "Open Link With",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "minAppVersion": "1.1",
     "description": "Open external link with specific browser / in-app view in Obsidian",
     "author": "MamoruDS",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-open-link-with",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "Open external link with specific browser / in-app view in Obsidian",
     "main": "dist/main.js",
     "scripts": {

--- a/src/click.ts
+++ b/src/click.ts
@@ -121,11 +121,25 @@ class LocalDocClickHandler {
         const win = evt.doc.win as MWindow
         const modifiers = getModifiersFromMouseEvt(evt)
         const clickable = checkClickable(el)
-        if (clickable.is_clickable === false) {
+        let fire = true
+        let url: string = clickable.url
+        if (win.oolwPendingUrls.length > 0) {
+            // win.oolwPendingUrls for getting correct urls from default open API
+            url = win.oolwPendingUrls.pop()
+        } else {
+            // for urls could be invalid (inner links)
+            if (url !== null && !getValidHttpURL(url)) {
+                fire = false
+                win._builtInOpen(url)
+            }
+        }
+        if (clickable.is_clickable === false && url === null) {
             return false
         }
         let { paneType } = clickable
-        let fire = true
+        if (url === null) {
+            fire = false
+        }
         if (clickable.modifier_rules.length > 0) {
             const checker = new RulesChecker(clickable.modifier_rules)
             const matched = checker.check(modifiers, {
@@ -150,20 +164,6 @@ class LocalDocClickHandler {
             fire = false
         }
         evt.preventDefault()
-        let url: string = clickable.url
-        if (win.oolwPendingUrls.length > 0) {
-            // win.oolwPendingUrls for getting correct urls from default open API
-            url = win.oolwPendingUrls.pop()
-        } else {
-            // for urls could be invalid (inner links)
-            if (url !== null && !getValidHttpURL(url)) {
-                fire = false
-                win._builtInOpen(url)
-            }
-        }
-        if (url === null) {
-            fire = false
-        }
         if (this.clickUilts._plugin.settings.enableLog) {
             log('info', 'click event (LocalDocClickHandler)', {
                 is_aux: this.handleAuxClick,

--- a/src/click.ts
+++ b/src/click.ts
@@ -66,16 +66,20 @@ const checkClickable = (el: Element): Clickable => {
             new MR.Exact([CTRL, ALT, SHIFT], 'window'),
         ]
     }
+    // - links in community plugins' readme
     if (res.is_clickable === false && el.tagName === 'A') {
         let p = el
         while (p.tagName !== 'BODY') {
-            if (p.classList.contains('community-modal-info')) {
+            if (p.classList.contains('internal-link')) {
+                break
+            } else if (p.classList.contains('community-modal-info')) {
                 res.is_clickable = true
                 res.url = el.getAttribute('href')
                 res.paneType =
                     el.getAttribute('target') === '_blank'
                         ? 'window'
                         : res.paneType
+                break
             }
             p = p.parentElement
         }

--- a/src/click.ts
+++ b/src/click.ts
@@ -154,6 +154,12 @@ class LocalDocClickHandler {
         if (win.oolwPendingUrls.length > 0) {
             // win.oolwPendingUrls for getting correct urls from default open API
             url = win.oolwPendingUrls.pop()
+        } else {
+            // for urls could be invalid (inner links)
+            if (url !== null && !getValidHttpURL(url)) {
+                fire = false
+                win._builtInOpen(url)
+            }
         }
         if (url === null) {
             fire = false

--- a/src/view.ts
+++ b/src/view.ts
@@ -17,8 +17,13 @@ class InAppView extends ItemView {
         }, 10)
     }
     async onOpen(): Promise<void> {
+        const frame_styles: string[] = [
+            'height: 100%',
+            'width: 100%',
+            'background-color: white', // for pages with no background
+        ]
         this.frame = document.createElement('iframe')
-        this.frame.setAttr('style', 'height: 100%; width:100%')
+        this.frame.setAttr('style', frame_styles.join('; '))
         this.frame.setAttr('src', this.url)
         this.containerEl.children[1].appendChild(this.frame)
     }


### PR DESCRIPTION
-   fixed: no longer ignores non-clickable elements with a valid pending URL [#20](https://github.com/mamoruds/obsidian-open-link-with/issues/20)
-   fixed: blocks internal links under the .community-modal-info class [#19](https://github.com/mamoruds/obsidian-open-link-with/issues/20)
-   improved: adds background to in-app view iframe [#21](https://github.com/mamoruds/obsidian-open-link-with/issues/21)